### PR TITLE
REP-1106 Enable project-specific URN OAI set

### DIFF
--- a/src/main/resources/config/reposis_intr2dok/mycore.properties
+++ b/src/main/resources/config/reposis_intr2dok/mycore.properties
@@ -114,6 +114,10 @@ MCR.OAIDataProvider.MetadataFormat.oai_datacite.Schema=http://schema.datacite.or
 
 # Set specifications
 MCR.OAIDataProvider.OAI2.Sets=doc-type,open_access,openaire,driver,ec_fundedresources,GENRE,ddc,xmetadissplus
+
+# Enable the URN set configured by reposis_common.
+MCR.OAIDataProvider.OAI2.Sets=%MCR.OAIDataProvider.OAI2.Sets%,urn
+MCR.OAIDataProvider.OAI2.Sets.urn.Query=mods.identifier:urn* AND mods.identifier:*0301-*
 MCR.OAIDataProvider.OAI2.Sets.ddc.URI=xslStyle:classification2sets:classification:metadata:10:children:DDC
 MCR.OAIDataProvider.OAI2.Sets.ddc.Classification=DDC
 


### PR DESCRIPTION
## Changes

- enable the `urn` OAI set provided by `reposis_common`
- override the shared query with the project-specific `urn:nbn:de:0301-` namespace

```properties
MCR.OAIDataProvider.OAI2.Sets.urn.Query=mods.identifier:urn* AND mods.identifier:*0301-*
```

Production check: 18,617 records match the query.

Ticket: REP-1106